### PR TITLE
Fixes equals issue in FP48 macro. 

### DIFF
--- a/src/fp48.c.in
+++ b/src/fp48.c.in
@@ -105,7 +105,7 @@ void FP48_YYY_zero(FP48_YYY *w)
 /* SU= 16 */
 int FP48_YYY_equals(FP48_YYY *x,FP48_YYY *y)
 {
-    if (FP16_YYY_equals(&(x->a),&(y->a)) && FP16_YYY_equals(&(x->b),&(y->b)) && FP16_YYY_equals(&(x->b),&(y->b)))
+    if (FP16_YYY_equals(&(x->a),&(y->a)) && FP16_YYY_equals(&(x->b),&(y->b)) && FP16_YYY_equals(&(x->c),&(y->c)))
         return 1;
     return 0;
 }


### PR DESCRIPTION
Current template incorrectly compares 'b' component twice and ignores 'c'.

While unlikely to happen in general usage - i.e. what are the chances that two FP16 components are equal but the last one isn't? - it did surface in a specific instance for me.