### PR TITLE
Fix some uninitialised variable issues

### DIFF
--- a/src/ecp2.c.in
+++ b/src/ecp2.c.in
@@ -539,9 +539,8 @@ void ECP2_ZZZ_frob(ECP2_ZZZ *P,FP2_YYY *X)
 void ECP2_ZZZ_mul4(ECP2_ZZZ *P,ECP2_ZZZ Q[4],BIG_XXX u[4])
 {
     int i,j,k,nb,pb,bt;
-    // NOTE(Matthias): I don't know whether initialising with 0
-    // makes any sense at all, but even a bad value is better than
-    // undefined behaviour.
+    // We set W to 0 to provide a (hopefully) safe default,
+    // for when it gets read from before being written to otherwise.
     ECP2_ZZZ T[8],W={0};
     BIG_XXX t[4],mt;
     sign8 w[NLEN_XXX*BASEBITS_XXX+1];

--- a/src/ecp2.c.in
+++ b/src/ecp2.c.in
@@ -539,7 +539,10 @@ void ECP2_ZZZ_frob(ECP2_ZZZ *P,FP2_YYY *X)
 void ECP2_ZZZ_mul4(ECP2_ZZZ *P,ECP2_ZZZ Q[4],BIG_XXX u[4])
 {
     int i,j,k,nb,pb,bt;
-    ECP2_ZZZ T[8],W;
+    // NOTE(Matthias): I don't know whether initialising with 0
+    // makes any sense at all, but even a bad value is better than
+    // undefined behaviour.
+    ECP2_ZZZ T[8],W={0};
     BIG_XXX t[4],mt;
     sign8 w[NLEN_XXX*BASEBITS_XXX+1];
     sign8 s[NLEN_XXX*BASEBITS_XXX+1];

--- a/src/ff.c.in
+++ b/src/ff.c.in
@@ -859,9 +859,8 @@ void FF_WWW_ct_2w_pow(BIG_XXX r[], BIG_XXX *T[], BIG_XXX *E[], int k, int w, BIG
     sign32 index, e;
 
 #ifndef C99
-    // NOTE(Matthias): I don't know whether initialising with 0
-    // makes any sense at all, but even a bad value is better than
-    // undefined behaviour.
+    // Initialise to 0 to provide a (hopefully) safe default,
+    // for when it gets read from before being written to otherwise.
     BIG_XXX ws[FFLEN_WWW]={0};
 #else
     BIG_XXX ws[plen];

--- a/src/ff.c.in
+++ b/src/ff.c.in
@@ -859,7 +859,10 @@ void FF_WWW_ct_2w_pow(BIG_XXX r[], BIG_XXX *T[], BIG_XXX *E[], int k, int w, BIG
     sign32 index, e;
 
 #ifndef C99
-    BIG_XXX ws[FFLEN_WWW];
+    // NOTE(Matthias): I don't know whether initialising with 0
+    // makes any sense at all, but even a bad value is better than
+    // undefined behaviour.
+    BIG_XXX ws[FFLEN_WWW]={0};
 #else
     BIG_XXX ws[plen];
 #endif

--- a/src/fp12.c.in
+++ b/src/fp12.c.in
@@ -731,9 +731,8 @@ void FP12_YYY_pow(FP12_YYY *r,FP12_YYY *a,BIG_XXX b)
 void FP12_YYY_pow4(FP12_YYY *p,FP12_YYY *q,BIG_XXX u[4])
 {
     int i,j,k,nb,pb,bt;
-    // NOTE(Matthias): I don't know whether initialising with 0
-    // makes any sense at all, but even a bad value is better than
-    // undefined behaviour.
+    // Initialise r to 0 to provide a (hopefully) safe default,
+    // for when it gets read from before being written to otherwise.
     FP12_YYY g[8],r={0};
     BIG_XXX t[4],mt;
     sign8 w[NLEN_XXX*BASEBITS_XXX+1];
@@ -943,4 +942,3 @@ void FP12_YYY_cmove(FP12_YYY *f,FP12_YYY *g,int d)
     d=~(d-1);
     f->type^=(f->type^g->type)&d;
 }
-

--- a/src/fp12.c.in
+++ b/src/fp12.c.in
@@ -731,7 +731,10 @@ void FP12_YYY_pow(FP12_YYY *r,FP12_YYY *a,BIG_XXX b)
 void FP12_YYY_pow4(FP12_YYY *p,FP12_YYY *q,BIG_XXX u[4])
 {
     int i,j,k,nb,pb,bt;
-    FP12_YYY g[8],r;
+    // NOTE(Matthias): I don't know whether initialising with 0
+    // makes any sense at all, but even a bad value is better than
+    // undefined behaviour.
+    FP12_YYY g[8],r={0};
     BIG_XXX t[4],mt;
     sign8 w[NLEN_XXX*BASEBITS_XXX+1];
     sign8 s[NLEN_XXX*BASEBITS_XXX+1];


### PR DESCRIPTION
Just a band-aid, but better a wrong value (which only affects one computation) than using an unitialised value, because undefined behaviour affects everything.